### PR TITLE
GPII-2106: Workaround to close firefox when keying elaine out

### DIFF
--- a/gpii/node_modules/settingsHandlers/src/NoSettingsHandler.js
+++ b/gpii/node_modules/settingsHandlers/src/NoSettingsHandler.js
@@ -20,4 +20,5 @@ var fluid = require("infusion"),
     settingsHandlers = fluid.registerNamespace("gpii.settingsHandlers");
 
 settingsHandlers.noSettings = fluid.identity;
+settingsHandlers.noSettings.set = fluid.identity;
 

--- a/testData/deviceReporter/installedSolutions.json
+++ b/testData/deviceReporter/installedSolutions.json
@@ -153,6 +153,10 @@
 
     {
         "id": "trace.easyOne.communicator.windows"
+    },
+
+    {
+        "id": "org.nvda-project"
     }
 
 ]

--- a/testData/deviceReporter/installedSolutions.json
+++ b/testData/deviceReporter/installedSolutions.json
@@ -149,6 +149,10 @@
 
     {
         "id": "net.gpii.uioPlus"
+    },
+
+    {
+        "id": "trace.easyOne.communicator.windows"
     }
 
 ]

--- a/testData/solutions/win32.json5
+++ b/testData/solutions/win32.json5
@@ -1633,6 +1633,7 @@
                     "filename": "firefox.exe"
             }
         ],
+        "configure": [ "settings.configure" ],
         "isInstalled": [
             {
                 "type": "gpii.deviceReporter.alwaysInstalled"


### PR DESCRIPTION
Hey Ale, just in case there's a need to create another last minute build for the demo, here's a workaround that closes firefox when keying-out with user elaine. You can read more information here: https://issues.gpii.net/browse/GPII-2106

Also, added "trace.easyOne.communicator.windows" into the installedSolutions file as you're using the static device reporter now.